### PR TITLE
show: use HTTP Host header instead of env var

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -97,7 +97,6 @@ in
         wantedBy = [ "multi-user.target" ];
         environment.SHELFIE_PORT = toString(cfg.port);
         environment.SHELFIE_STORAGE = cfg.dataDir;
-        environment.SHELFIE_DOMAIN = cfg.appDomain;
       };
 
       services.nginx = lib.mkIf cfg.configureNginx {

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,11 +107,12 @@ fn index(tmpl: web::Data<tera::Tera>, _: HttpRequest) -> Result<impl Responder> 
 }
 
 /// Display an image ID
-fn display(tmpl: web::Data<tera::Tera>, id: Path<String>) -> Result<impl Responder> {
+fn display(tmpl: web::Data<tera::Tera>, request: HttpRequest, id: Path<String>) -> Result<impl Responder> {
     let mut ctx = tera::Context::new();
     ctx.insert("id", &*id);
-    ctx.insert("app_domain", &env::var("SHELFIE_DOMAIN")
-        .map_err(|_| error::ErrorInternalServerError("Environment variable SHELFIE_DOMAIN is not set"))?);
+    ctx.insert("host", request.headers().get("host")
+        .ok_or(error::ErrorBadRequest("Missing Host header"))?
+        .to_str().map_err(|_| error::ErrorBadRequest("Invalid Host header"))?);
 
     Ok(HttpResponse::Ok().content_type("text/html").body(
         tmpl.render("show.html", &ctx)

--- a/templates/show.html
+++ b/templates/show.html
@@ -3,8 +3,8 @@
 {% block meta %}
 <meta property="og:type" content="article">
 <meta property="og:title" content="View picture - Shelfie">
-<meta property="og:url " content="https://{{ app_domain }}/id/{{ id }}">
-<meta property="og:image" content="https://{{ app_domain }}/images/{{ id }}">
+<meta property="og:url " content="https://{{ host }}/id/{{ id }}">
+<meta property="og:image" content="https://{{ host }}/images/{{ id }}">
 {% endblock meta %}
 
 {% block style %}


### PR DESCRIPTION
The request contains all the information we need to get the host, so I removed the SHELFIE_DOMAIN environment variable entirely and used that instead.

I also renamed the parameter to "host", because it's not necessarily just the domain -- it could also include a port.