### PR TITLE
Handle multipart-related issues properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,8 +1365,11 @@ name = "shelfie"
 version = "0.1.0"
 dependencies = [
  "actix-files 0.1.0-betsa.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-multipart 0.1.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-utils 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ tera = "0.11"
 # Utility crates
 rand = "0.6"
 hex = "0.3"
+
+[dev-dependencies]
+actix-http = "*"
+bytes = "*"
+actix-utils = "*"


### PR DESCRIPTION
Hey,

While having a play with this crate, I was able to crash the server in two different ways:

- A malformed boundary check is present in `actix`, but it is extremely rudimentary. In practice, it doesn't actually check if a *single* boundary is present in the uploaded data. As a result, you can send total garbage and still pass through `actix-multipart` unscathed, leading to a stream with 0 elements (and therefore an empty vector at the end). You were unwrapping `vec.get(0)` with the assumption that this wasn't possible - I've added a test and corrected this behavior

- The upload path is clearly aimed at uploading one file, yet every single element in the multipart request is passed to `save_file`, leading to possible inode exhaustion from a malicious attacker. I've fixed this without modifying the underlying `save_file` behaviour by forcing the stream to contain at most one element (through `take`) and then fusing it (just in case)

The second issue does not have an associated test as there is no easy way to redirect `save_file` to a temporary directory while running tests, and it is not possible to send it to the test artifact directory due to the use of `env::current_dir()`. I might fix that at some point.